### PR TITLE
Adding vcpkg as toolchain for ubuntu action

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCatch2_DIR=../vcpkg_installed/x64-linux/share/catch2
+          cmake .. -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake
           cmake --build .
           ctest .
           cmake --install .

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,2 +1,2 @@
-#find_package(SQLiteCpp CONFIG REQUIRED)
-#find_package(cppzmq CONFIG REQUIRED)
+find_package(SQLiteCpp CONFIG REQUIRED)
+find_package(cppzmq CONFIG REQUIRED)


### PR DESCRIPTION
Adding back dependencies and testing the action in ubutu finds them at build time.