### PR TITLE
Adding simulator init initial implementation

### DIFF
--- a/include/cadmium/iadevs/basic_models/generator.h
+++ b/include/cadmium/iadevs/basic_models/generator.h
@@ -25,6 +25,11 @@
 
 #pragma once
 
+#include <cadmium/iadevs/utils/ia_interval.h>
+
+#include<string>
+
+namespace cadmium::iadevs::basic_models {
 /**
  * This is a simple implementation of a UA Generator model approximated
  * by using double intervals.
@@ -33,9 +38,58 @@
  * the functions MAY be cached by the simulator.
  * All IA functions have to return bounded results, including TA to be computable.
  */
-
-namespace cadmium::iadevs::basic_models {
 struct generator {
+  // The state is only tracks the time until next internal event is emitted
+  using state_t = cadmium::iadevs::interval<int>;
+  // The time is defined as a set of integers representing ms (no unit support yet)
+  using time_t = cadmium::iadevs::interval<int>;
+  //At this point I'm only implementing what is required to make Simulator.init
+  //function work end to end.
+  //TODO: add everything else.
+  //Ref: UA-DEVS paper section 6.1
+  //Function init(initstate q, R^+_I t)→ void
+  //state =q_state
+  //t_last = (t − q_time ).apply(timebounds)
+  //t_next = (t_last + a.TA(state)).apply(timebounds)
 
+  /**
+   * Bounded_time_advance_i is an optional function
+   * Depending on the datatype used for time_t bounding time_advance and
+   * reapplying bound after adding/subtracting t_next/t_last at the simulator
+   * level can add extra error to the obtained time interval.
+   * However, in cases the error is acceptable, this function can be accompanied
+   * by deserialize/serialize time_advance functions to cache its calculation and
+   * speed up the simulation.
+   * @param state is the interval of partial states for the time_advance calculation
+   * @return
+   */
+  time_t bounded_time_advance_i(const state_t &state) const {
+    time_t l{};
+    l.set_bounded(997, true, 1005, true);
+    return l - state;
+  }
+
+  // The simulator needs to call this function to apply the proper bounded addition when
+  time_t time_bound_t_add_time_advance(const state_t &state, const time_t &t) const {
+    return time_bound_add(t, bounded_time_advance_i(state));
+  }
+
+  time_t time_bound_add(const time_t &t1, const time_t &t2) const {
+    return t1 + t2;
+  }
+
+  time_t time_bound_t_subtract_time_advance(const time_t &t1, const time_t &t2) const {
+    return t1 - t2;
+  }
+
+  //serialize : to enable caching
+  std::string serialize_time_interval(const time_t &t) const {
+    return "[0,0]";
+  }
+
+  //deserialize : to enable cache read
+  time_t deserialize_time_interval(const std::string &t) const {
+    return time_t{};
+  }
 };
 }

--- a/include/cadmium/iadevs/concepts.h
+++ b/include/cadmium/iadevs/concepts.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2023, Damian Vicino
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include<concepts>
+
+namespace cadmium::iadevs {
+
+template<typename T>
+concept is_atomic = requires(T a, typename T::state_t t) {
+  { a.bounded_time_advance_i(t) } -> std::convertible_to<typename T::time_t>;
+};
+
+}

--- a/include/cadmium/iadevs/engine/simulator.h
+++ b/include/cadmium/iadevs/engine/simulator.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2023, Damian Vicino
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cadmium/iadevs/concepts.h>
+
+namespace cadmium::iadevs::engine {
+
+/**
+ * sim_state_triplet wraps state, t_next, t_last to be passed back to coordinators
+ * @tparam STATE
+ * @tparam TIME
+ */
+template<typename STATE, typename TIME>
+struct sim_state_triplet {
+  STATE state;
+  TIME t_last;
+  TIME t_next;
+};
+
+/**
+ * This implements the simulation algorithms for IA-DEVS atomic models
+ * @tparam model_t an atomic IA model
+ */
+template<typename model_t> requires cadmium::iadevs::is_atomic<model_t>
+struct simulator {
+  using sim_state_t = sim_state_triplet<typename model_t::state_t, typename model_t::time_t>;
+
+  sim_state_t init(typename model_t::state_t state, typename model_t::time_t time) {
+    model_t m;
+    auto time_advance = m.bounded_time_advance_i(state);
+    auto t_next = m.time_bound_add(time, time_advance);
+    return sim_state_t{state, time, t_next};
+  }
+};
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,5 +12,30 @@ target_link_libraries(
         ia_devs_cd_lib
         Catch2::Catch2WithMain
 )
-
 add_test(NAME test_interval COMMAND test_interval)
+
+add_executable(test_generator)
+target_sources(
+        test_generator
+        PRIVATE
+        test_generator.cpp
+)
+target_link_libraries(
+        test_generator
+        ia_devs_cd_lib
+        Catch2::Catch2WithMain
+)
+add_test(NAME test_generator COMMAND test_generator)
+
+add_executable(test_simulator)
+target_sources(
+        test_simulator
+        PRIVATE
+        test_simulator.cpp
+)
+target_link_libraries(
+        test_simulator
+        ia_devs_cd_lib
+        Catch2::Catch2WithMain
+)
+add_test(NAME test_simulator COMMAND test_simulator)

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2023, Damian Vicino
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cadmium/iadevs/basic_models/generator.h>
+
+#include <catch.hpp>
+
+SCENARIO("Generator basic model TA_I function", "[GENERATOR]") {
+  GIVEN("A generator that outputs a 1 or 2 every 997 to 1005 millisecond") {
+    WARN("Current test assumes time is in milliseconds, units are not yet implemented");
+    cadmium::iadevs::basic_models::generator g{};
+    WHEN("bounded_time_advance_i is called with q_state ([0, 0], [0, 0])") {
+      cadmium::iadevs::basic_models::generator::state_t s{};
+      s.set_bounded(0, true, 0, true);
+      auto i = g.bounded_time_advance_i(s);
+      THEN("interval [997, 1005] is returned") {
+        REQUIRE_FALSE(i.is_empty());
+        REQUIRE_FALSE(i.is_left_unbounded());
+        REQUIRE_FALSE(i.is_right_unbounded());
+        REQUIRE_FALSE(i.is_unbounded());
+        REQUIRE(i.is_lower_endpoint_closed());
+        REQUIRE(i.is_upper_endpoint_closed());
+        REQUIRE(i.get_lower_endpoint_value() == 997);
+        REQUIRE(i.get_upper_endpoint_value() == 1005);
+      }
+    }
+  }
+}
+
+SCENARIO("Generator basic model time_bound_add function", "[GENERATOR]") {
+  GIVEN("A generator") {
+    WARN("Current test assumes time is in milliseconds, units are not yet implemented");
+    cadmium::iadevs::basic_models::generator g{};
+    WHEN("time_bound_add [997, 1005] to  [997, 1005]") {
+      cadmium::iadevs::basic_models::generator::time_t t1{};
+      t1.set_bounded(997, true, 1005, true);
+      auto i = g.time_bound_add(t1, t1);
+      THEN("interval [1994, 2010] is returned") {
+        REQUIRE_FALSE(i.is_empty());
+        REQUIRE_FALSE(i.is_left_unbounded());
+        REQUIRE_FALSE(i.is_right_unbounded());
+        REQUIRE_FALSE(i.is_unbounded());
+        REQUIRE(i.is_lower_endpoint_closed());
+        REQUIRE(i.is_upper_endpoint_closed());
+        REQUIRE(i.get_lower_endpoint_value() == 1994);
+        REQUIRE(i.get_upper_endpoint_value() == 2010);
+      }
+    }
+  }
+}

--- a/test/test_interval.cpp
+++ b/test/test_interval.cpp
@@ -185,8 +185,7 @@ SCENARIO("Intervals additions", "[INTERVALS]") {
         REQUIRE(k.get_lower_endpoint_value() == 6);
         REQUIRE(k.get_upper_endpoint_value() == 9);
       }
-    }
-    WHEN("both intervals endpoints are open") {
+    }WHEN("both intervals endpoints are open") {
       i.set_bounded(1, false, 2, false);
       j.set_bounded(5, false, 7, false);
       THEN("their addition matching endpoints are open") {
@@ -195,6 +194,92 @@ SCENARIO("Intervals additions", "[INTERVALS]") {
         REQUIRE_FALSE(k.is_upper_endpoint_closed());
         REQUIRE(k.get_lower_endpoint_value() == 6);
         REQUIRE(k.get_upper_endpoint_value() == 9);
+      }
+    }
+  }
+}
+
+SCENARIO("Equality of intervals", "[INTERVALS]") {
+  GIVEN("an empty interval") {
+    cadmium::iadevs::interval<int> i{};
+    WHEN("comparing to a empty interval") {
+      cadmium::iadevs::interval<int> j{};
+      THEN("they are seen as equal") {
+        REQUIRE(i == j);
+      }
+    }WHEN("comparing to an unbounded interval") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_unbounded();
+      THEN("they are considered not equal") {
+        REQUIRE_FALSE(i == j);
+      }
+    }WHEN("comparing to a bounded interval [1, 2)") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_bounded(1, true, 2, false);
+      THEN("they are considered not equal") {
+        REQUIRE_FALSE(i == j);
+      }
+    }
+  }GIVEN("a unbounded interval") {
+    cadmium::iadevs::interval<int> i{};
+    i.set_unbounded();
+    WHEN("comparing to an unbounded interval") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_unbounded();
+      THEN("they are considered not equal") {
+        REQUIRE(i == j);
+      }
+    }WHEN("comparing to a bounded interval [1, 2)") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_bounded(1, true, 2, false);
+      THEN("they are considered not equal") {
+        REQUIRE_FALSE(i == j);
+      }
+    }
+  }GIVEN("a bounded interval [1, 2)") {
+    cadmium::iadevs::interval<int> i{};
+    i.set_bounded(1, true, 2, false);
+    WHEN("comparing to a bounded interval [1, 2)") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_bounded(1, true, 2, false);
+      THEN("they are considered equal") {
+        REQUIRE(i == j);
+      }
+    }WHEN("comparing to a bounded interval [1, 2]") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_bounded(1, true, 2, true);
+      THEN("they are not considered equal") {
+        REQUIRE_FALSE(i == j);
+      }
+    }WHEN("comparing to a bounded interval (1, 2)") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_bounded(1, false, 2, false);
+      THEN("they are not considered equal") {
+        REQUIRE_FALSE(i == j);
+      }
+    }WHEN("comparing to a bounded interval [1, 3)") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_bounded(1, true, 3, false);
+      THEN("they are not considered equal") {
+        REQUIRE_FALSE(i == j);
+      }
+    }WHEN("comparing to a bounded interval [0, 2)") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_bounded(0, true, 2, false);
+      THEN("they are not considered equal") {
+        REQUIRE_FALSE(i == j);
+      }
+    }WHEN("comparing to a semi bounded interval (inf-, 2)") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_right_unbounded_with_lower_endpoint_value(2, false);
+      THEN("they are not considered equal") {
+        REQUIRE_FALSE(i == j);
+      }
+    }WHEN("comparing to a semi bounded interval [1, inf+)") {
+      cadmium::iadevs::interval<int> j{};
+      j.set_left_unbounded_with_upper_endpoint_value(1, true);
+      THEN("they are not considered equal") {
+        REQUIRE_FALSE(i == j);
       }
     }
   }

--- a/test/test_simulator.cpp
+++ b/test/test_simulator.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2023, Damian Vicino
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cadmium/iadevs/basic_models/generator.h>
+#include <cadmium/iadevs/engine/simulator.h>
+
+#include <catch.hpp>
+
+SCENARIO("Generator is simulated", "[SIMULATOR]") {
+  GIVEN("A simulator for a generator model") {
+    WARN("Current test assumes time is in milliseconds, units are not yet implemented");
+    cadmium::iadevs::engine::simulator<cadmium::iadevs::basic_models::generator> sg{};
+    WHEN("init is called with [0,0] initial S and [0, 0] initial T") {
+      cadmium::iadevs::basic_models::generator::time_t t{};
+      t.set_bounded(0, true, 0, true);
+      cadmium::iadevs::basic_models::generator::state_t s{};
+      s.set_bounded(0, true, 0, true);
+      auto sg_init_ret = sg.init(s, t);
+      THEN("same state and t_last is returned, t_next is now [997, 1005]") {
+        cadmium::iadevs::basic_models::generator::time_t t_next_expected{};
+        t_next_expected.set_bounded(997, true, 1005, true);
+        REQUIRE(sg_init_ret.state == s);
+        REQUIRE(sg_init_ret.t_last == t);
+        REQUIRE(sg_init_ret.t_next == t_next_expected);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Initial draft implementation of simulator init method and basic testing.
Further details about interval representation to support the simulator init testing.
Enough details of Generator model to be used for testing. 
